### PR TITLE
Display MQTT read and control credentials, fix location selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus",
-  "version": "1.11.1",
+  "version": "1.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus",
-      "version": "1.11.1",
+      "version": "1.11.9",
       "license": "Argus 2018",
       "dependencies": {
         "@angular/animations": "^21.1.4",

--- a/src/app/pages/config/network/mqtt.component.html
+++ b/src/app/pages/config/network/mqtt.component.html
@@ -75,39 +75,22 @@
         }
         @if (mqttForm.controls["mqttEnabled"].value && !mqttForm.controls["mqttExternal"].value) {
           <span>
-            <h3 i18n="@@network mqtt internal broker info">Internal MQTT Broker read</h3>
-            <mat-list>
-              <mat-list-item>
-                <span matListItemTitle i18n="@@network mqtt url">MQTT URL</span>
-                {{ getMqttUrl() }}
-              </mat-list-item>
-              <mat-list-item>
-                <span matListItemTitle i18n="@@network mqtt username">MQTT Username</span>
-                {{ getMqttUsername() }}
-                <button
-                  type="button"
-                  mat-icon-button
-                  color="primary"
-                  onclick="this.blur()"
-                  (click)="copyToClipboard(getMqttUsername())"
-                >
-                  <mat-icon>content_copy</mat-icon>
-                </button>
-              </mat-list-item>
-              <mat-list-item>
-                <span matListItemTitle i18n="@@network mqtt password">MQTT Password</span>
-                {{ getMqttPassword() || "No password set" }}
-                <button
-                  type="button"
-                  mat-icon-button
-                  color="primary"
-                  onclick="this.blur()"
-                  (click)="copyToClipboard(getMqttPassword())"
-                >
-                  <mat-icon>content_copy</mat-icon>
-                </button>
-              </mat-list-item>
-            </mat-list>
+            <h3 i18n="@@network mqtt internal broker read">Internal MQTT Broker read only</h3>
+            <p i18n="@@network mqtt internal broker read info">
+              For external clients that only display the state of the system.
+            </p>
+            <ng-container
+              *ngTemplateOutlet="internalCredentials; context: { config: mqttInternalRead }"
+            ></ng-container>
+            <h3 i18n="@@network mqtt internal broker control">
+              Internal MQTT Broker read and control
+            </h3>
+            <p i18n="@@network mqtt internal broker control info">
+              For external clients that also arm and disarm the system, like Home Assistant.
+            </p>
+            <ng-container
+              *ngTemplateOutlet="internalCredentials; context: { config: mqttInternalControl }"
+            ></ng-container>
           </span>
         }
         <div class="form-actions">
@@ -127,3 +110,38 @@
     }
   </mat-expansion-panel>
 }
+
+<ng-template #internalCredentials let-config="config">
+  <mat-list>
+    <mat-list-item>
+      <span matListItemTitle i18n="@@network mqtt url">MQTT URL</span>
+      {{ getMqttUrl(config) }}
+    </mat-list-item>
+    <mat-list-item>
+      <span matListItemTitle i18n="@@network mqtt username">MQTT Username</span>
+      {{ getMqttUsername(config) }}
+      <button
+        type="button"
+        mat-icon-button
+        color="primary"
+        onclick="this.blur()"
+        (click)="copyToClipboard(getMqttUsername(config))"
+      >
+        <mat-icon>content_copy</mat-icon>
+      </button>
+    </mat-list-item>
+    <mat-list-item>
+      <span matListItemTitle i18n="@@network mqtt password">MQTT Password</span>
+      {{ getMqttPassword(config) || "No password set" }}
+      <button
+        type="button"
+        mat-icon-button
+        color="primary"
+        onclick="this.blur()"
+        (click)="copyToClipboard(getMqttPassword(config))"
+      >
+        <mat-icon>content_copy</mat-icon>
+      </button>
+    </mat-list-item>
+  </mat-list>
+</ng-template>

--- a/src/app/pages/config/network/mqtt.component.ts
+++ b/src/app/pages/config/network/mqtt.component.ts
@@ -17,6 +17,7 @@ import { MatSnackBar } from "@angular/material/snack-bar"
 import { finalize } from "rxjs/operators"
 
 import { Clipboard } from "@angular/cdk/clipboard"
+import { NgTemplateOutlet } from "@angular/common"
 import { MatListModule } from "@angular/material/list"
 import { ConfigurationBaseComponent } from "@app/configuration-base/configuration-base.component"
 import { Option } from "@app/models"
@@ -46,7 +47,8 @@ const scheduleMicrotask = Promise.resolve(null)
     MatButtonModule,
     MatDividerModule,
     MatListModule,
-    MatIconModule
+    MatIconModule,
+    NgTemplateOutlet
   ]
 })
 export class MqttComponent
@@ -56,6 +58,7 @@ export class MqttComponent
   mqttForm: FormGroup
   mqttConnection: Option = null
   mqttInternalRead: Option = null
+  mqttInternalControl: Option = null
   mqttExternalPublish: Option = null
   private mqttFormSubscriptions: Subscription[] = []
 
@@ -94,6 +97,10 @@ export class MqttComponent
     forkJoin({
       mqttConnection: this.configService.getOption("mqtt", "connection"),
       mqttInternalRead: this.configService.getOption("mqtt", "internal_read"),
+      mqttInternalControl: this.configService.getOption(
+        "mqtt",
+        "internal_control"
+      ),
       mqttExternalPublish: this.configService.getOption(
         "mqtt",
         "external_publish"
@@ -101,9 +108,15 @@ export class MqttComponent
     })
       .pipe(finalize(() => this.loader.display(false)))
       .subscribe(
-        ({ mqttConnection, mqttInternalRead, mqttExternalPublish }) => {
+        ({
+          mqttConnection,
+          mqttInternalRead,
+          mqttInternalControl,
+          mqttExternalPublish
+        }) => {
           this.mqttConnection = mqttConnection
           this.mqttInternalRead = mqttInternalRead
+          this.mqttInternalControl = mqttInternalControl
           this.mqttExternalPublish = mqttExternalPublish
 
           this.updateMqttForm(this.mqttConnection, this.mqttExternalPublish)
@@ -191,37 +204,31 @@ export class MqttComponent
     )
   }
 
-  getMqttUrl() {
-    if (
+  private usesInternalBroker() {
+    return (
       getValue(this.mqttConnection.value, "enabled") &&
       !getValue(this.mqttConnection.value, "external")
-    ) {
-      const protocol = getValue(this.mqttInternalRead.value, "tls_enabled")
-        ? "mqtts"
-        : "mqtt"
-      const hostname = getValue(this.mqttInternalRead.value, "hostname")
-      const port = getValue(this.mqttInternalRead.value, "port")
+    )
+  }
+
+  getMqttUrl(config: Option) {
+    if (this.usesInternalBroker()) {
+      const protocol = getValue(config?.value, "tls_enabled") ? "mqtts" : "mqtt"
+      const hostname = getValue(config?.value, "hostname")
+      const port = getValue(config?.value, "port")
       return `${protocol}://${hostname}:${port}`
     }
   }
 
-  getMqttUsername() {
-    if (
-      getValue(this.mqttConnection.value, "enabled") &&
-      !getValue(this.mqttConnection.value, "external")
-    ) {
-      const username = getValue(this.mqttInternalRead.value, "username")
-      return username
+  getMqttUsername(config: Option) {
+    if (this.usesInternalBroker()) {
+      return getValue(config?.value, "username")
     }
   }
 
-  getMqttPassword() {
-    if (
-      getValue(this.mqttConnection.value, "enabled") &&
-      !getValue(this.mqttConnection.value, "external")
-    ) {
-      const password = getValue(this.mqttInternalRead.value, "password")
-      return password
+  getMqttPassword(config: Option) {
+    if (this.usesInternalBroker()) {
+      return getValue(config?.value, "password")
     }
   }
 

--- a/src/app/pages/location/location-details.component.spec.ts
+++ b/src/app/pages/location/location-details.component.spec.ts
@@ -1,7 +1,8 @@
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http"
 import { ComponentFixture, TestBed } from "@angular/core/testing"
-import { ActivatedRoute } from "@angular/router"
+import { ActivatedRoute, Router } from "@angular/router"
 
+import { Location } from "@app/models"
 import { AUTHENTICATION_SERVICE } from "@app/tokens"
 import { of } from "rxjs"
 
@@ -13,7 +14,42 @@ describe("LocationDetailsComponent", () => {
   let component: LocationDetailsComponent
   let fixture: ComponentFixture<LocationDetailsComponent>
 
+  /**
+   * Location without domain/port, so that configureBackend() does not perform any request.
+   */
+  function createLocation(id: string, name: string): Location {
+    const location = new Location()
+    location.id = id
+    location.name = name
+    location.scheme = "https"
+    return location
+  }
+
+  /**
+   * Prepare the component for onSubmit() as if the form was filled for the given location.
+   */
+  function editLocation(location: Location) {
+    component.location = location
+    component.updateForm(location)
+  }
+
+  let storageListeners: ((event: StorageEvent) => void)[] = []
+
+  /**
+   * Collect the keys of the storage events dispatched by the component.
+   * The listeners are removed again in afterEach().
+   */
+  function recordStorageKeys(): string[] {
+    const keys: string[] = []
+    const listener = (event: StorageEvent) => keys.push(event.key)
+    storageListeners.push(listener)
+    window.addEventListener("storage", listener)
+    return keys
+  }
+
   beforeEach(async () => {
+    localStorage.clear()
+
     await TestBed.configureTestingModule({
       declarations: [LocationDetailsComponent],
       imports: [],
@@ -28,7 +64,8 @@ describe("LocationDetailsComponent", () => {
           useClass: environment.notificationService
         },
         provideHttpClient(withInterceptorsFromDi()),
-        { provide: ActivatedRoute, useValue: { params: of({ id: "123" }) } }
+        { provide: ActivatedRoute, useValue: { params: of({ id: "123" }) } },
+        { provide: Router, useValue: { navigate: () => Promise.resolve(true) } }
       ]
     }).compileComponents()
 
@@ -37,7 +74,76 @@ describe("LocationDetailsComponent", () => {
     fixture.detectChanges()
   })
 
+  afterEach(() => {
+    storageListeners.forEach(listener =>
+      window.removeEventListener("storage", listener)
+    )
+    storageListeners = []
+    localStorage.clear()
+  })
+
   it("should create", () => {
     expect(component).toBeTruthy()
+  })
+
+  it("should select the first created location", async () => {
+    const location = createLocation("a".repeat(64), "Default")
+    editLocation(location)
+    const storageKeys = recordStorageKeys()
+
+    await component.onSubmit()
+
+    expect(localStorage.getItem("selectedLocationId")).toEqual(location.id)
+    expect(component.selectedLocationId).toEqual(location.id)
+    expect(storageKeys).toContain("selectedLocationId")
+    expect(storageKeys).toContain("locations")
+  })
+
+  it("should keep the selected location when an other location is added", async () => {
+    const selected = createLocation("a".repeat(64), "Selected")
+    localStorage.setItem("locations", JSON.stringify([selected]))
+    localStorage.setItem("selectedLocationId", selected.id)
+
+    editLocation(createLocation("b".repeat(64), "New"))
+    const storageKeys = recordStorageKeys()
+
+    await component.onSubmit()
+
+    expect(localStorage.getItem("selectedLocationId")).toEqual(selected.id)
+    expect(component.selectedLocationId).toEqual(selected.id)
+    expect(storageKeys).not.toContain("selectedLocationId")
+    expect(JSON.parse(localStorage.getItem("locations")).length).toEqual(2)
+  })
+
+  it("should repair a selected location id pointing to a missing location", async () => {
+    localStorage.setItem(
+      "locations",
+      JSON.stringify([createLocation("a".repeat(64), "Existing")])
+    )
+    localStorage.setItem("selectedLocationId", "c".repeat(64))
+
+    const location = createLocation("b".repeat(64), "New")
+    editLocation(location)
+
+    await component.onSubmit()
+
+    expect(localStorage.getItem("selectedLocationId")).toEqual(location.id)
+    expect(component.selectedLocationId).toEqual(location.id)
+  })
+
+  it("should update an existing location without changing the selection", async () => {
+    const selected = createLocation("a".repeat(64), "Old name")
+    localStorage.setItem("locations", JSON.stringify([selected]))
+    localStorage.setItem("selectedLocationId", selected.id)
+
+    editLocation(createLocation(selected.id, "Old name"))
+    component.locationForm.controls.name.setValue("New name")
+
+    await component.onSubmit()
+
+    const locations: Location[] = JSON.parse(localStorage.getItem("locations"))
+    expect(locations.length).toEqual(1)
+    expect(locations[0].name).toEqual("New name")
+    expect(localStorage.getItem("selectedLocationId")).toEqual(selected.id)
   })
 })

--- a/src/app/pages/location/location-details.component.ts
+++ b/src/app/pages/location/location-details.component.ts
@@ -6,9 +6,16 @@ import { QuestionDialogComponent } from "@app/components/question-dialog/questio
 import { Location } from "@app/models"
 import { AuthenticationService, NotificationService } from "@app/services"
 import { AUTHENTICATION_SERVICE } from "@app/tokens"
+import { configureBackend } from "@app/utils"
 import { environment } from "@environments/environment"
 import { LocationVersion } from "../../models/version"
-import { getLocationName, LocationTestResult, testLocation } from "./location"
+import {
+  getLocationName,
+  LocationTestResult,
+  saveLocations,
+  syncSelectedLocationId,
+  testLocation
+} from "./location"
 
 @Component({
   selector: "app-location-details",
@@ -259,7 +266,7 @@ export class LocationDetailsComponent {
     return false
   }
 
-  onSubmit() {
+  async onSubmit() {
     const location = this.prepareLocation()
     const locations: Location[] = JSON.parse(
       localStorage.getItem("locations") || "[]"
@@ -272,13 +279,7 @@ export class LocationDetailsComponent {
       locations.push(location)
     }
 
-    localStorage.setItem("locations", JSON.stringify(locations))
-    window.dispatchEvent(
-      new StorageEvent("storage", {
-        key: "locations",
-        newValue: JSON.stringify(locations)
-      })
-    )
+    saveLocations(locations)
 
     const notificationsEnabled = this.locationForm?.value?.notifications
     if (notificationsEnabled === true) {
@@ -287,6 +288,11 @@ export class LocationDetailsComponent {
     if (notificationsEnabled === false) {
       this.disableNotifications()
     }
+
+    // select the new location if there is no working selection yet
+    this.selectedLocationId = syncSelectedLocationId(locations, location.id)
+    // configure the backend before navigating, otherwise the first request fails
+    await configureBackend()
 
     if (this.isMultiLocation) {
       this.router.navigate(["/locations"])
@@ -316,11 +322,18 @@ export class LocationDetailsComponent {
       }
     })
 
-    dialogRef.afterClosed().subscribe(result => {
+    dialogRef.afterClosed().subscribe(async result => {
       if (result === "ok") {
         locations = locations.filter(x => x.id !== this.location.id)
-        localStorage.setItem("locations", JSON.stringify(locations))
-        this.router.navigate(["/locations"])
+        saveLocations(locations)
+        this.selectedLocationId = syncSelectedLocationId(locations)
+        await configureBackend()
+
+        if (this.isMultiLocation) {
+          this.router.navigate(["/locations"])
+        } else {
+          this.router.navigate(["/setup"])
+        }
       }
     })
   }

--- a/src/app/pages/location/location-list.component.ts
+++ b/src/app/pages/location/location-list.component.ts
@@ -25,7 +25,13 @@ import {
   LocationVersion,
   parseVersion
 } from "../../models/version"
-import { LocationTestResult, testLocation } from "./location"
+import {
+  LocationTestResult,
+  saveLocations,
+  setSelectedLocationId,
+  syncSelectedLocationId,
+  testLocation
+} from "./location"
 
 @Component({
   selector: "location-list",
@@ -159,36 +165,13 @@ export class LocationListComponent extends ConfigurationBaseComponent {
   }
 
   onLogin(locationId: string) {
-    localStorage.setItem("selectedLocationId", locationId)
-    window.dispatchEvent(
-      new StorageEvent("storage", {
-        key: "selectedLocationId",
-        newValue: locationId
-      })
-    )
+    setSelectedLocationId(locationId)
     window.location.href = "/login"
   }
 
   onSave() {
-    const locations = JSON.stringify(this.locations)
-    localStorage.setItem("locations", locations)
-    window.dispatchEvent(
-      new StorageEvent("storage", { key: "locations", newValue: locations })
-    )
-
-    if (this.locations.length === 1) {
-      this.selectedLocationId = this.locations[0].id
-      localStorage.setItem(
-        "selectedLocationId",
-        this.selectedLocationId.toString()
-      )
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: "selectedLocationId",
-          newValue: this.selectedLocationId.toString()
-        })
-      )
-    }
+    saveLocations(this.locations)
+    this.selectedLocationId = syncSelectedLocationId(this.locations)
 
     configureBackend().then(() => {
       console.log("Backend configured")

--- a/src/app/pages/location/location.ts
+++ b/src/app/pages/location/location.ts
@@ -22,6 +22,61 @@ export class LocationTestResult {
   secondaryBoardVersion: string = null
 }
 
+/**
+ * Persist the location list and notify the listeners (AppComponent, EventService)
+ * through the storage event bus.
+ */
+export function saveLocations(locations: Location[]): void {
+  const value = JSON.stringify(locations)
+  localStorage.setItem("locations", value)
+  window.dispatchEvent(
+    new StorageEvent("storage", { key: "locations", newValue: value })
+  )
+}
+
+/**
+ * Persist the selected location id and notify the listeners. Pass null to clear it.
+ */
+export function setSelectedLocationId(locationId: string | null): void {
+  if (locationId) {
+    localStorage.setItem("selectedLocationId", locationId)
+  } else {
+    localStorage.removeItem("selectedLocationId")
+  }
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key: "selectedLocationId",
+      newValue: locationId
+    })
+  )
+}
+
+/**
+ * Ensure that the selected location id points to an existing location.
+ *
+ * A valid selection is never changed, so adding a location cannot hijack an active session.
+ * Otherwise the preferred location is selected, falling back to the first one.
+ *
+ * @returns The selected location id afterwards.
+ */
+export function syncSelectedLocationId(
+  locations: Location[],
+  preferredId: string | null = null
+): string | null {
+  const current = localStorage.getItem("selectedLocationId")
+  if (current && locations.some(location => location.id === current)) {
+    return current
+  }
+
+  const preferred =
+    preferredId && locations.some(location => location.id === preferredId)
+      ? preferredId
+      : null
+  const next = preferred ?? locations[0]?.id ?? null
+  setSelectedLocationId(next)
+  return next
+}
+
 function testUrl(url: string): Observable<boolean> {
   if (!url) {
     return

--- a/src/locales/messages.hu.xlf
+++ b/src/locales/messages.hu.xlf
@@ -1786,9 +1786,21 @@
         <source> Allow insecure TLS connection </source>
         <target state="translated"> Nem biztonságos TLS kapcsolat engedélyezése </target>
       </trans-unit>
-      <trans-unit id="network mqtt internal broker info" datatype="html">
-        <source>Internal MQTT Broker read</source>
-        <target state="translated">Belső MQTT Broker olvasás</target>
+      <trans-unit id="network mqtt internal broker control" datatype="html">
+        <source>Internal MQTT Broker read and control</source>
+        <target state="translated">Belső MQTT Broker olvasás és vezérlés</target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker control info" datatype="html">
+        <source> For external clients that also arm and disarm the system, like Home Assistant. </source>
+        <target state="translated"> Külső klienseknek, amelyek a rendszert élesítik és hatástalanítják is, például a Home Assistant. </target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read" datatype="html">
+        <source>Internal MQTT Broker read only</source>
+        <target state="translated">Belső MQTT Broker csak olvasás</target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read info" datatype="html">
+        <source> For external clients that only display the state of the system. </source>
+        <target state="translated"> Külső klienseknek, amelyek csak megjelenítik a rendszer állapotát. </target>
       </trans-unit>
       <trans-unit id="network mqtt url" datatype="html">
         <source>MQTT URL</source>

--- a/src/locales/messages.it.xlf
+++ b/src/locales/messages.it.xlf
@@ -1786,9 +1786,21 @@
         <source> Allow insecure TLS connection </source>
         <target state="new"> Allow insecure TLS connection </target>
       </trans-unit>
-      <trans-unit id="network mqtt internal broker info" datatype="html">
-        <source>Internal MQTT Broker read</source>
-        <target state="new">Internal MQTT Broker read</target>
+      <trans-unit id="network mqtt internal broker control" datatype="html">
+        <source>Internal MQTT Broker read and control</source>
+        <target state="new">Internal MQTT Broker read and control</target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker control info" datatype="html">
+        <source> For external clients that also arm and disarm the system, like Home Assistant. </source>
+        <target state="new"> For external clients that also arm and disarm the system, like Home Assistant. </target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read" datatype="html">
+        <source>Internal MQTT Broker read only</source>
+        <target state="new">Internal MQTT Broker read only</target>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read info" datatype="html">
+        <source> For external clients that only display the state of the system. </source>
+        <target state="new"> For external clients that only display the state of the system. </target>
       </trans-unit>
       <trans-unit id="network mqtt url" datatype="html">
         <source>MQTT URL</source>

--- a/src/locales/messages.xlf
+++ b/src/locales/messages.xlf
@@ -1368,8 +1368,17 @@
       <trans-unit id="network mqtt insecure tls" datatype="html">
         <source> Allow insecure TLS connection </source>
       </trans-unit>
-      <trans-unit id="network mqtt internal broker info" datatype="html">
-        <source>Internal MQTT Broker read</source>
+      <trans-unit id="network mqtt internal broker control" datatype="html">
+        <source>Internal MQTT Broker read and control</source>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker control info" datatype="html">
+        <source> For external clients that also arm and disarm the system, like Home Assistant. </source>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read" datatype="html">
+        <source>Internal MQTT Broker read only</source>
+      </trans-unit>
+      <trans-unit id="network mqtt internal broker read info" datatype="html">
+        <source> For external clients that only display the state of the system. </source>
       </trans-unit>
       <trans-unit id="network mqtt password" datatype="html">
         <source>MQTT Password</source>


### PR DESCRIPTION
   ## Summary                                                                                                                 
                                                                                                                              
   Makes the credentials of the internal MQTT broker account with control                                                     
   permissions (`mqtt/internal_control`) visible in the configuration UI. Only the                                            
   read-only account was shown before, so external clients that arm and disarm the                                            
   system ? such as Home Assistant ? had no way to obtain their credentials from the                                          
   UI. Requires the backend to serve the `mqtt/internal_control` option; without it                                           
   the section stays empty instead of breaking.                                                                               
                                                                                                                              
   Also fixes the location selection, which was not maintained reliably: after                                                
   saving the first location none was selected, and after a delete the selection                                              
   could still point at a location that no longer exists, making the first request                                            
   after navigation fail.

   ## Changes                                                                                                                 
   - Load and display both internal broker accounts (read only, and read + control)                                           
     on the MQTT configuration page, each with a note explaining its purpose.                                                 
   - Extract the credential list into an `ng-template` reused per account, and pass                                           
     the account to render into `getMqttUrl()` / `getMqttUsername()` /                                                        
     `getMqttPassword()` instead of reading `mqttInternalRead` directly.                                                      
   - Extract the location storage helpers `saveLocations()`,                                                                  
     `setSelectedLocationId()` and `syncSelectedLocationId()` into `location.ts`,                                             
     replacing the duplicated `localStorage` and `StorageEvent` code in the location                                          
     list and details components.                                                                                             
   - Keep `selectedLocationId` pointing at an existing location on add, update and                                            
     delete, without overwriting a selection that is already valid, and await                                                 
     `configureBackend()` before navigating.                                                                                  
   - Navigate to `/setup` instead of `/locations` after deleting a location in                                                
     single-location mode.                                                                                                    
   - Add tests covering the selection behaviour for the create, add, repair and                                               
     update cases.                                                                                                            
   - Add the four new i18n units for the MQTT headings and notes, translated for                                              
     `hu` and `it`.                                                                                                           
   - Bump the `package-lock.json` version to `1.11.9` to match `package.json`.